### PR TITLE
Deployment updates.

### DIFF
--- a/Camunda.Api.Client/Deployment/DeploymentService.cs
+++ b/Camunda.Api.Client/Deployment/DeploymentService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
 namespace Camunda.Api.Client.Deployment
 {
@@ -28,11 +29,13 @@ namespace Camunda.Api.Client.Deployment
         /// <param name="tenantId">The tenant id for the deployment to be created.</param>
         public Task<DeploymentInfo> Create(string deploymentName, bool duplicateFiltering, bool changedOnly, string deploymentSource, string tenantId = null,
             params ResourceDataContent[] resources) => _api.Create(
-                    new PlainTextContent("deployment-name", deploymentName),
-                    new PlainTextContent("enable-duplicate-filtering", duplicateFiltering.ToString().ToLower()),
-                    new PlainTextContent("deploy-changed-only", changedOnly.ToString().ToLower()),
-                    new PlainTextContent("deployment-source", deploymentSource ?? "undefined"),
-                    tenantId == null ? null : new PlainTextContent("tenant-id", tenantId), resources);
+                new HttpContentMultipartItem<PlainTextContent>(new PlainTextContent("deployment-name", deploymentName)),
+                new HttpContentMultipartItem<PlainTextContent>(new PlainTextContent("enable-duplicate-filtering", duplicateFiltering.ToString().ToLower())),
+                new HttpContentMultipartItem<PlainTextContent>(new PlainTextContent("deploy-changed-only", changedOnly.ToString().ToLower())),
+                new HttpContentMultipartItem<PlainTextContent>(new PlainTextContent("deployment-source", deploymentSource ?? "undefined")),
+                tenantId == null ? null : new HttpContentMultipartItem<PlainTextContent>(new PlainTextContent("tenant-id", tenantId)),
+                resources.Select(r => new HttpContentMultipartItem<ResourceDataContent>(r)).ToArray());
+
 
         /// <summary>
         /// Create a deployment.

--- a/Camunda.Api.Client/Deployment/IDeploymentRestService.cs
+++ b/Camunda.Api.Client/Deployment/IDeploymentRestService.cs
@@ -32,8 +32,10 @@ namespace Camunda.Api.Client.Deployment
         Task<HttpResponseMessage> GetDeploymentResourceData(string deploymentId, string resourceId);
 
         [Post("/deployment/create"), Multipart]
-        Task<DeploymentInfo> Create(PlainTextContent deploymentName, PlainTextContent enableDuplicateFiltering,
-            PlainTextContent deployChangedOnly, PlainTextContent deploymentSource, PlainTextContent tenantId, IEnumerable<ResourceDataContent> resources);
+        Task<DeploymentInfo> Create(HttpContentMultipartItem<PlainTextContent> deploymentName, HttpContentMultipartItem<PlainTextContent> enableDuplicateFiltering,
+            HttpContentMultipartItem<PlainTextContent> deployChangedOnly, HttpContentMultipartItem<PlainTextContent> deploymentSource,
+            HttpContentMultipartItem<PlainTextContent> tenantId, params HttpContentMultipartItem<ResourceDataContent>[] resources);
+
 
     }
 }

--- a/Camunda.Api.Client/HttpContentMultipartItem.cs
+++ b/Camunda.Api.Client/HttpContentMultipartItem.cs
@@ -1,0 +1,22 @@
+﻿using Refit;
+using System;
+using System.Net.Http;
+
+namespace Camunda.Api.Client
+{
+    public class HttpContentMultipartItem<T> : MultipartItem
+        where T : HttpContent
+    {
+        public HttpContentMultipartItem(T content, string fileName = "") : base(fileName, null)
+        {
+            Content = content ?? throw new ArgumentNullException("content");
+        }
+
+        public T Content { get; set; }
+
+        protected override HttpContent CreateContent()
+        {
+            return Content;
+        }
+    }
+}


### PR DESCRIPTION
Fixes deployments. Encapsulates previously used HttpContent implementations in an implementation of Refit's MultipartItem. Also caters for a dynamic amount of resources in a single deployment.

Keep up the great work!